### PR TITLE
Handle cPL Update for Tick Rollbacks

### DIFF
--- a/contracts/libraries/EpochMap.sol
+++ b/contracts/libraries/EpochMap.sol
@@ -71,7 +71,7 @@ library EpochMap {
     function getIndices(
         int24 tick,
         ILimitPoolStructs.Immutables memory constants
-    ) internal view returns (
+    ) internal pure returns (
             uint256 tickIndex,
             uint256 wordIndex,
             uint256 blockIndex,

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.13;
 import './math/ConstantProduct.sol';
 import '../interfaces/ILimitPool.sol';
 import '../interfaces/ILimitPoolStructs.sol';
-import 'hardhat/console.sol';
 
 library TickMap {
 
@@ -293,7 +292,7 @@ library TickMap {
         int24 tick,
         int24 tickSpacing,
         bool zeroForOne
-    ) internal view returns (
+    ) internal pure returns (
         int24 roundedTick
     ) {
         roundedTick = tick / tickSpacing * tickSpacing;
@@ -302,6 +301,5 @@ library TickMap {
             roundedTick -= tickSpacing;
         else if (!zeroForOne && roundedTick > 0)
             roundedTick += tickSpacing;
-        console.log('rounding tick', uint24(-(-49 * 10 / 10)), uint24(-tick), uint24(-roundedTick));
     }
 }

--- a/contracts/libraries/pool/BurnCall.sol
+++ b/contracts/libraries/pool/BurnCall.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.13;
 import '../../interfaces/ILimitPoolStructs.sol';
 import '../Positions.sol';
 import '../utils/Collect.sol';
-import 'hardhat/console.sol';
 
 library BurnCall {
     event Burn(
@@ -36,7 +35,6 @@ library BurnCall {
             || params.claim != (params.zeroForOne ? params.lower : params.upper))
         // or position has been crossed into
         {
-            console.log('position update');
             // if position has been crossed into
             (
                 cache.state,
@@ -60,7 +58,6 @@ library BurnCall {
                 cache.constants
             );
         } else {
-            console.log('position remove');
             // if position hasn't been crossed into
             (, cache.pool) = Positions.remove(
                 positions,
@@ -78,7 +75,6 @@ library BurnCall {
                 cache.constants
             );
         }
-        console.log('cache position last price', cache.position.claimPriceLast, cache.pool.price);
         Collect.burn(
             cache,
             positions,

--- a/contracts/libraries/pool/MintCall.sol
+++ b/contracts/libraries/pool/MintCall.sol
@@ -86,7 +86,6 @@ library MintCall {
                     // set epoch on start tick to signify position being crossed into
                     cache.pool.swapEpoch += 1;
                     cache.position.claimPriceLast = TickMath.getPriceAtTick(params.lower, cache.constants);
-                    if (params.lower == 100) console.log('liquidity mint delta check', cache.liquidityMinted, uint128(ticks[params.upper].liquidityDelta));
                     EpochMap.set(params.lower, cache.pool.swapEpoch, tickMap, cache.constants);
                 } else if (priceLower == cache.pool.price) {
                     cache.pool.liquidity += uint128(cache.liquidityMinted);
@@ -108,7 +107,6 @@ library MintCall {
                     cache.pool.liquidity += uint128(cache.liquidityMinted);
                 }
             }
-            if (params.lower == 0) console.log('tick 100 epoch check2', EpochMap.get(100, tickMap, cache.constants));
             save(cache.pool, pool);
             positions[params.to][params.lower][params.upper] = cache.position;
         }

--- a/contracts/libraries/utils/Collect.sol
+++ b/contracts/libraries/utils/Collect.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.13;
 import '../../interfaces/ILimitPoolStructs.sol';
 import '../Positions.sol';
 import '../utils/SafeTransfers.sol';
-import 'hardhat/console.sol';
 
 library Collect {
     function burn(
@@ -19,8 +18,6 @@ library Collect {
         // store amounts for transferOut
         uint128 amountIn  = positions[msg.sender][params.lower][params.upper].amountIn;
         uint128 amountOut = positions[msg.sender][params.lower][params.upper].amountOut;
-
-        console.log('cPL check 2', uint24(-params.claim), positions[msg.sender][params.lower][params.upper].claimPriceLast);
 
         // console.log('position amounts', amountIn, amountOut);
 

--- a/contracts/libraries/utils/SafeCast.sol
+++ b/contracts/libraries/utils/SafeCast.sol
@@ -7,7 +7,7 @@ library SafeCast {
     /// @notice Cast a uint256 to a uint128, revert on overflow
     /// @param y The uint256 to be downcasted
     /// @return z The downcasted integer, now type uint128
-    function toUint128(uint256 y) internal view returns (uint128 z) {
+    function toUint128(uint256 y) internal pure returns (uint128 z) {
         require((z = uint128(y)) == y);
     }
 


### PR DESCRIPTION
Upon a second undercut taking place in the same tick region, the cPL should not be updated it the user claims again once the tick is rolled back.