### PR TITLE
TK-7: Inclusive option for TickMap.next()

### DIFF
--- a/contracts/libraries/Claims.sol
+++ b/contracts/libraries/Claims.sol
@@ -91,7 +91,7 @@ library Claims {
         } else if (params.amount > 0) {
             /// @dev - partway claim is valid as long as liquidity is not being removed
             int24 claimTickNext = params.zeroForOne
-                ? TickMap.next(tickMap, params.claim, constants.tickSpacing)
+                ? TickMap.next(tickMap, params.claim, constants.tickSpacing, false)
                 : TickMap.previous(tickMap, params.claim, constants.tickSpacing, false);
             // if we cleared the final tick of their position, this is the wrong claim tick
             if (params.zeroForOne ? claimTickNext > params.upper

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -231,7 +231,7 @@ library Positions {
         if (params.zeroForOne) {
             if (EpochMap.get(params.lower, tickMap, constants)
                         > cache.position.epochLast) {
-                int24 nextTick = TickMap.next(tickMap, params.lower, constants.tickSpacing);
+                int24 nextTick = TickMap.next(tickMap, params.lower, constants.tickSpacing, false);
                 if (pool.price > cache.priceLower ||
                     EpochMap.get(nextTick, tickMap, constants)
                         > cache.position.epochLast) {

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -88,9 +88,14 @@ library TickMap {
         unchecked {
             // rounds up to ensure relative position
             if (tick % (tickSpacing / 2) != 0 || inclusive) {
-                if (tick >= 0 || (inclusive && tick % (tickSpacing / 2) == 0)) {
-                    if (tick < (ConstantProduct.maxTick(tickSpacing) - tickSpacing / 2))
+                if (tick < (ConstantProduct.maxTick(tickSpacing) - tickSpacing / 2)) {
+                    /// @dev - ensures we cross when tick >= 0
+                    if (tick >= 0) {
                         tick += tickSpacing / 2;
+                    } else if (inclusive && tick % (tickSpacing / 2) == 0) {
+                    /// @dev - ensures we cross when tick == tickAtPrice
+                        tick += tickSpacing / 2;
+                    }
                 }
             }
             (
@@ -119,11 +124,17 @@ library TickMap {
     function next(
         ILimitPoolStructs.TickMap storage tickMap,
         int24 tick,
-        int16 tickSpacing
+        int16 tickSpacing,
+        bool inclusive
     ) internal view returns (
         int24 nextTick
     ) {
         unchecked {
+            /// @dev - handles tickAtPrice being past tickSpacing / 2
+            if (inclusive && tick % tickSpacing != 0) {
+                tick -= 1;
+            }
+            /// @dev - handles negative ticks rounding up
             if (tick % (tickSpacing / 2) != 0) {
                 if (tick < 0)
                     if (tick > (ConstantProduct.minTick(tickSpacing) + tickSpacing / 2))

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -106,8 +106,6 @@ library Ticks {
         )
     {
         (cache.crossTick,) = TickMap.roundHalf(pool.tickAtPrice, cache.constants, pool.price);
-        if (!params.zeroForOne && cache.crossTick % cache.constants.tickSpacing != 0) cache.crossTick -= 1;
-
         cache = ILimitPoolStructs.SwapCache({
             state: cache.state,
             constants: cache.constants,
@@ -116,7 +114,7 @@ library Ticks {
             liquidity: pool.liquidity,
             cross: true,
             crossTick: params.zeroForOne ? TickMap.previous(tickMap, cache.crossTick, cache.constants.tickSpacing, true) 
-                                         : TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing),
+                                         : TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing, true),
             crossPrice: 0,
             input:  0,
             output: 0,
@@ -182,7 +180,6 @@ library Ticks {
         uint160
     ) {
         (cache.crossTick,) = TickMap.roundHalf(pool.tickAtPrice, cache.constants, pool.price);
-        if (!params.zeroForOne && cache.crossTick % cache.constants.tickSpacing != 0) cache.crossTick -= 1;
         cache = ILimitPoolStructs.SwapCache({
             state: cache.state,
             constants: cache.constants,
@@ -191,7 +188,7 @@ library Ticks {
             liquidity: pool.liquidity,
             cross: true,
             crossTick: params.zeroForOne ? TickMap.previous(tickMap, cache.crossTick, cache.constants.tickSpacing, true) 
-                                         : TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing),
+                                         : TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing, true),
             crossPrice: 0,
             input:  0,
             output: 0,
@@ -349,7 +346,7 @@ library Ticks {
         if (pool.liquidity > 0) return (cache, pool);
 
         if (zeroForOne) {
-            pool.tickAtPrice = TickMap.next(tickMap, pool.tickAtPrice, cache.constants.tickSpacing);
+            pool.tickAtPrice = TickMap.next(tickMap, pool.tickAtPrice, cache.constants.tickSpacing, true);
             if (pool.tickAtPrice < ConstantProduct.maxTick(cache.constants.tickSpacing)) {
                 EpochMap.set(pool.tickAtPrice, pool.swapEpoch, tickMap, cache.constants);
             }
@@ -405,7 +402,7 @@ library Ticks {
         if (zeroForOne) {
             cache.crossTick = TickMap.previous(tickMap, cache.crossTick, cache.constants.tickSpacing, false);
         } else {
-            cache.crossTick = TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing);
+            cache.crossTick = TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing, false);
         }
         return (pool, cache);
     }
@@ -426,7 +423,7 @@ library Ticks {
         if (zeroForOne) {
             cache.crossTick = TickMap.previous(tickMap, cache.crossTick, cache.constants.tickSpacing, false);
         } else {
-            cache.crossTick = TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing);
+            cache.crossTick = TickMap.next(tickMap, cache.crossTick, cache.constants.tickSpacing, false);
         }
         return (pool, cache);
     }


### PR DESCRIPTION
This PR also handles `pool.tickAtPrice` being greater than or equal to the half `tickSpacing` when calling `Ticks.unlock()`.