### PR TITLE
Price Bounds on Implementation Contract

### DIFF
--- a/contracts/LimitPool.sol
+++ b/contracts/LimitPool.sol
@@ -233,6 +233,10 @@ contract LimitPool is
         );
     }
 
+    function priceBounds(int16 tickSpacing) external pure returns (uint160, uint160) {
+        return ConstantProduct.priceBounds(tickSpacing);
+    }
+
     function _onlyOwner() private view {
         if (msg.sender != owner()) revert OwnerOnly();
     }

--- a/contracts/LimitPoolFactory.sol
+++ b/contracts/LimitPoolFactory.sol
@@ -67,8 +67,10 @@ contract LimitPoolFactory is
         constants.owner = owner;
         constants.factory = original;
         constants.tickSpacing = tickSpacing;
-        constants.bounds.min = ConstantProduct.minPrice(constants.tickSpacing);
-        constants.bounds.max = ConstantProduct.maxPrice(constants.tickSpacing);
+        (
+            constants.bounds.min,
+            constants.bounds.max
+        ) = ILimitPool(implementation).priceBounds(constants.tickSpacing);
 
         // launch pool
         pool = implementation.cloneDeterministic({

--- a/contracts/interfaces/ILimitPool.sol
+++ b/contracts/interfaces/ILimitPool.sol
@@ -46,4 +46,11 @@ interface ILimitPool is ILimitPoolStructs {
         uint128 token0Fees,
         uint128 token1Fees
     );
+
+    function priceBounds(
+        int16 tickSpacing
+    ) external pure returns (
+        uint160 minPrice,
+        uint160 maxPrice
+    );
 }


### PR DESCRIPTION
This PR moves the price bounds calculation in the factory to the implementation contract.

This way if we ever add implementations other than Constant Product, the implementation will tell us the min and max prices possible.