### PR TITLE
`claimPriceLast` switched to boolean

### DIFF
--- a/contracts/interfaces/ILimitPoolStructs.sol
+++ b/contracts/interfaces/ILimitPoolStructs.sol
@@ -32,11 +32,11 @@ interface ILimitPoolStructs {
     }
 
     struct Position {
-        uint160 claimPriceLast; // highest price claimed at
-        uint128 liquidity; // expected amount to be used not actual
         uint128 amountIn; // token amount already claimed; balance
         uint128 amountOut; // necessary for non-custodial positions
+        uint128 liquidity; // expected amount to be used not actual
         uint32  epochLast;  // last epoch this position was updated at
+        bool crossedInto; // whether the position was crossed into already
     }
 
     struct PriceBounds {

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -398,7 +398,7 @@ library Positions {
         // clear position if empty
         if (cache.position.liquidity == 0) {
             cache.position.epochLast = 0;
-            cache.position.claimPriceLast = 0;
+            cache.position.crossedInto = false;
         }
 
         // round back claim tick for storage
@@ -456,7 +456,7 @@ library Positions {
         // clear position values if empty
         if (cache.position.liquidity == 0) {
             cache.position.epochLast = 0;
-            cache.position.claimPriceLast = 0;
+            cache.position.crossedInto = false;
         }    
         return cache.position;
     }

--- a/contracts/libraries/pool/BurnCall.sol
+++ b/contracts/libraries/pool/BurnCall.sol
@@ -27,7 +27,7 @@ library BurnCall {
     ) external returns (ILimitPoolStructs.BurnCache memory) {
         if (params.lower >= params.upper) require (false, 'InvalidPositionBounds()');
         if (cache.position.epochLast == 0) require(false, 'PositionNotFound()');
-        if (cache.position.claimPriceLast > 0
+        if (cache.position.crossedInto
             || params.claim != (params.zeroForOne ? params.lower : params.upper)
             || cache.position.epochLast < (params.zeroForOne ? EpochMap.get(params.lower, tickMap, cache.constants)
                                                              : EpochMap.get(params.upper, tickMap, cache.constants)))

--- a/contracts/libraries/pool/MintCall.sol
+++ b/contracts/libraries/pool/MintCall.sol
@@ -85,7 +85,7 @@ library MintCall {
                     /// @auditor - double check liquidity is set correctly for this in insertSingle
                     cache.pool.liquidity += uint128(cache.liquidityMinted);
                     cache.pool.swapEpoch += 1;
-                    cache.position.claimPriceLast = ConstantProduct.getPriceAtTick(params.lower, cache.constants);
+                    cache.position.crossedInto = true;
                     // set epoch on start tick to signify position being crossed into
                     /// @auditor - this is safe assuming we have swapped at least this far on the other side
                     EpochMap.set(params.lower, cache.pool.swapEpoch, tickMap, cache.constants);
@@ -101,7 +101,7 @@ library MintCall {
                     cache.pool.tickAtPrice = params.upper;
                     cache.pool.liquidity += uint128(cache.liquidityMinted);
                     cache.pool.swapEpoch += 1;
-                    cache.position.claimPriceLast = ConstantProduct.getPriceAtTick(params.upper, cache.constants);
+                    cache.position.crossedInto = true;
                     // set epoch on start tick to signify position being crossed into
                     /// @auditor - this is safe assuming we have swapped at least this far on the other side
                     EpochMap.set(params.upper, cache.pool.swapEpoch, tickMap, cache.constants);


### PR DESCRIPTION
The value of `claimPriceLast` has been refactored to a bool called `crossedInto`.

We only need `claimPriceLast` to know if the position has been crossed into, so having a boolean serves this same purpose while also taking up less storage space.