### PR TITLE
Mark Undertick Tick After Position

### DIFF
--- a/contracts/interfaces/ILimitPoolStructs.sol
+++ b/contracts/interfaces/ILimitPoolStructs.sol
@@ -35,7 +35,7 @@ interface ILimitPoolStructs {
         uint128 amountIn; // token amount already claimed; balance
         uint128 amountOut; // necessary for non-custodial positions
         uint128 liquidity; // expected amount to be used not actual
-        uint32  epochLast;  // last epoch this position was updated at
+        uint32 epochLast;  // epoch when this position was created at
         bool crossedInto; // whether the position was crossed into already
     }
 

--- a/contracts/libraries/Claims.sol
+++ b/contracts/libraries/Claims.sol
@@ -82,7 +82,6 @@ library Claims {
             int24 claimTickNext = params.zeroForOne
                 ? TickMap.next(tickMap, params.claim, constants.tickSpacing, false)
                 : TickMap.previous(tickMap, params.claim, constants.tickSpacing, false);
-            console.log('claim tick next check', uint24(-claimTickNext));
             // if we cleared the final tick of their position, this is the wrong claim tick
             if (params.zeroForOne ? claimTickNext > params.upper
                                   : claimTickNext < params.lower) {
@@ -92,7 +91,6 @@ library Claims {
             /// @dev - if the next tick was crossed after position creation, the claim tick is incorrect
             /// @dev - we can cycle to find the right claim tick for the user
             uint32 claimTickNextAccumEpoch = EpochMap.get(claimTickNext, tickMap, constants);
-            console.log('claim tick epoch check', claimTickNextAccumEpoch, cache.position.epochLast);
             ///@dev - next swapEpoch should not be greater
             if (claimTickNextAccumEpoch > cache.position.epochLast) {
                 require (false, 'WrongTickClaimedAt5()');

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -151,8 +151,6 @@ library Positions {
         // save swapCache
         cache.swapCache = swapCache;
 
-        console.log('amount left for position', params.amount);
-
         return (
             params,
             cache

--- a/contracts/libraries/pool/BurnCall.sol
+++ b/contracts/libraries/pool/BurnCall.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.13;
 import '../../interfaces/ILimitPoolStructs.sol';
 import '../Positions.sol';
 import '../utils/Collect.sol';
+import 'hardhat/console.sol';
 
 library BurnCall {
     event BurnLimit(

--- a/contracts/libraries/pool/MintCall.sol
+++ b/contracts/libraries/pool/MintCall.sol
@@ -84,11 +84,9 @@ library MintCall {
                     cache.pool.tickAtPrice = params.lower;
                     /// @auditor - double check liquidity is set correctly for this in insertSingle
                     cache.pool.liquidity += uint128(cache.liquidityMinted);
-                    cache.pool.swapEpoch += 1;
                     cache.position.crossedInto = true;
                     // set epoch on start tick to signify position being crossed into
                     /// @auditor - this is safe assuming we have swapped at least this far on the other side
-                    EpochMap.set(params.lower, cache.pool.swapEpoch, tickMap, cache.constants);
                     emit Sync(cache.pool.price, cache.pool.liquidity);
                 }
             } else {
@@ -100,11 +98,9 @@ library MintCall {
                     cache.pool.price = priceUpper;
                     cache.pool.tickAtPrice = params.upper;
                     cache.pool.liquidity += uint128(cache.liquidityMinted);
-                    cache.pool.swapEpoch += 1;
                     cache.position.crossedInto = true;
                     // set epoch on start tick to signify position being crossed into
                     /// @auditor - this is safe assuming we have swapped at least this far on the other side
-                    EpochMap.set(params.upper, cache.pool.swapEpoch, tickMap, cache.constants);
                     emit Sync(cache.pool.price, cache.pool.liquidity);
                 }
             }


### PR DESCRIPTION
This PR adjusts the epoch setting process for undercuts.

Previously, it was setting the undercut tick epoch equal to the position created.

Now the undercut tick will have an epoch +1 of whatever the created position has.