### PR TITLE
RP1155-1: erc1155 support check for mint

### DIFF
--- a/contracts/utils/RangePoolERC1155.sol
+++ b/contracts/utils/RangePoolERC1155.sol
@@ -79,7 +79,10 @@ contract RangePoolERC1155 is
         uint256 _id,
         uint256 _amount,
         PoolsharkStructs.Immutables memory constants
-    ) external onlyCanonicalClones(constants) {
+    ) external 
+        onlyCanonicalClones(constants)
+        checkERC1155Support(_account)
+    {
         _mint(_account, _id, _amount);
     }
 
@@ -88,7 +91,9 @@ contract RangePoolERC1155 is
         uint256 _id,
         uint256 _amount,
         PoolsharkStructs.Immutables memory constants
-    ) external onlyCanonicalClones(constants) {
+    ) external
+        onlyCanonicalClones(constants)
+    {
         _burn(_account, _id, _amount);
     }
 
@@ -267,7 +272,7 @@ contract RangePoolERC1155 is
         return true;
     }
 
-        function _onlyCanonicalPools(
+    function _onlyCanonicalPools(
         PoolsharkStructs.Immutables memory constants
     ) private view returns (bool) {
         // generate key for pool


### PR DESCRIPTION
This PR adds an ERC1155 support check when minting range positions.

It checks that the address provided for `params.to` supports ERC1155 callbacks.